### PR TITLE
install with sudo

### DIFF
--- a/de/FirstSteps.rst
+++ b/de/FirstSteps.rst
@@ -29,7 +29,7 @@ Verwendung der Linux/MacOS-Version
 ----------------------------------
 
 Laden Sie die aktuelle OpenSlides Version für Linux/MacOS von
-http://openslides.org oder über den Python Package Index (PyPI) (``$ pip
+http://openslides.org oder über den Python Package Index (PyPI) (``$ sudo pip
 install openslides``) herunter. Die Installationsanleitung für diese
 Version finden Sie in der beiliegenden README.rst. Folgen Sie den
 Anweisungen der Anleitung.


### PR DESCRIPTION
Installation ohne sudo installiert zwar OpenSlides, allerdings wird der entsprechende Terminalbefehl (`$ openslides`) nicht installiert und OpenSlides muss manuell gestartet werden (`$ python __main__.py` im installationsverzeichnis)

Installation without sudo will install OpenSlides, but not the terminal command (`$ openslides`) and you have to start OpenSlides manually (`$ python __main__.py` in installation-directory)

(Using Ubuntu 15.04)
